### PR TITLE
Pid file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ venv.bak/
 
 # database
 makermon.db
+m_server.pid

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ venv.bak/
 # database
 makermon.db
 m_server.pid
+fcntl.py

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import sqlite3
 import tornado.ioloop
 import tornado.web
@@ -6,7 +7,11 @@ import tornado.web
 import database
 import uimodules
 
+
 PATH = os.path.dirname(os.path.realpath(__file__))
+pid = str( os.getpid() )
+pid_file = open( 'm_server.pid', 'r+' )
+pid_file.write( pid )
 
 class MainHandler(tornado.web.RequestHandler):
     def get(self):

--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
 import os
+import sys
+import fcntl
 import sqlite3
 import tornado.ioloop
 import tornado.web
@@ -9,8 +11,14 @@ import uimodules
 
 PATH = os.path.dirname(os.path.realpath(__file__))
 pid = str( os.getpid() )
-pid_file = open( 'm_server.pid', 'r+' )
-pid_file.write( pid )
+try:
+    pid_file = open( 'm_server.pid', 'w+' )
+    fcntl.flock( pid_file, fcntl.LOCK_EX | fcntl.LOCK_NB )
+    pid_file.write( pid )
+    pid_file.flush()
+except IOError:
+    print( "Failed to acquire lock on PID file, program must already be running" )
+    sys.exit()
 
 class MainHandler(tornado.web.RequestHandler):
     def get(self):

--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import sqlite3
 import tornado.ioloop
 import tornado.web


### PR DESCRIPTION
Adds pid file (m_server.pid) locking.  Shell script on pi will need to be updated with pid file location. 

fixes #8 

Anyone working on windows, fcntl library doesn't exist for windows.  There is a file in .gitignore fcntl.py create it and add this to it for the code to get it to run on windows (without actually locking the pid file).

```python
LOCK_EX = 0
LOCK_NB = 0

def fcntl(fd, op, arg=0):
    return 0
        
def ioctl(fd, op, arg=0, mutable_flag=True):
    if mutable_flag:
        return 0
    else:
        return ""
    
def flock(fd, op):
    return
        
def lockf(fd, operation, length=0, start=0, whence=0):
    return
```